### PR TITLE
fix: expose editorId in TuiEditorOptions interface

### DIFF
--- a/libs/tui/package.json
+++ b/libs/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-tui",
-  "version": "2.0.0",
+  "version": "2.1.0-rc.0",
   "nxpm": {
     "allowPackageName": true
   },

--- a/libs/tui/src/index.ts
+++ b/libs/tui/src/index.ts
@@ -2,3 +2,4 @@ export * from './lib/tui-editor.service';
 export * from './lib/tui-editor.component';
 export * from './lib/tui.module';
 export { highlightjsGraphql } from './lib/highlightjs.graphql';
+export { TuiEditorOptions } from './lib/tui-editor.options';

--- a/libs/tui/src/lib/tui-editor.component.ts
+++ b/libs/tui/src/lib/tui-editor.component.ts
@@ -8,32 +8,12 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
+import { TuiEditorOptions } from './tui-editor.options';
 import { TuiService } from './tui-editor.service';
 
 export interface MarkdownData {
   html: string;
   markdown: string;
-}
-
-export interface TuiEditorOptions {
-  previewStyle?: 'tab' | 'vertical';
-  previewHighlight?: boolean;
-  initialEditType?: 'markdown' | 'wysiwyg';
-  initialValue?: string;
-  height?: string;
-  minHeight?: string;
-  language?: string;
-  useDefaultHTMLSanitizer?: boolean;
-  useCommandShortcut?: boolean;
-  usageStatistics?: boolean;
-  toolbarItems?: string[];
-  hideModeSwitch?: boolean;
-  linkAttribute?: any;
-  extendedAutolinks?: boolean;
-  customConvertor?: any;
-  customHTMLRenderer?: any;
-  referenceDefinition?: boolean;
-  customHTMLSanitizer?: (params: any) => any;
 }
 
 @Component({
@@ -83,24 +63,20 @@ export class TuiComponent implements AfterViewInit {
   }
 
   changed() {
-    this.onChangeMarkdown.emit(
-      this.editor.getMarkdown((this.options as any).editorId)
-    );
-    this.onChangeHTML.emit(this.editor.getHtml((this.options as any).editorId));
+    this.onChangeMarkdown.emit(this.editor.getMarkdown(this.options.editorId));
+    this.onChangeHTML.emit(this.editor.getHtml(this.options.editorId));
     this.onChange.emit({
-      html: this.editor.getHtml((this.options as any).editorId),
-      markdown: this.editor.getMarkdown((this.options as any).editorId),
+      html: this.editor.getHtml(this.options.editorId),
+      markdown: this.editor.getMarkdown(this.options.editorId),
     });
   }
 
   blur() {
-    this.onBlurMarkdown.emit(
-      this.editor.getMarkdown((this.options as any).editorId)
-    );
-    this.onBlurHTML.emit(this.editor.getHtml((this.options as any).editorId));
+    this.onBlurMarkdown.emit(this.editor.getMarkdown(this.options.editorId));
+    this.onBlurHTML.emit(this.editor.getHtml(this.options.editorId));
     this.onBlur.emit({
-      html: this.editor.getHtml((this.options as any).editorId),
-      markdown: this.editor.getMarkdown((this.options as any).editorId),
+      html: this.editor.getHtml(this.options.editorId),
+      markdown: this.editor.getMarkdown(this.options.editorId),
     });
   }
 }

--- a/libs/tui/src/lib/tui-editor.options.ts
+++ b/libs/tui/src/lib/tui-editor.options.ts
@@ -1,0 +1,21 @@
+export interface TuiEditorOptions {
+  previewStyle?: 'tab' | 'vertical';
+  previewHighlight?: boolean;
+  initialEditType?: 'markdown' | 'wysiwyg';
+  initialValue?: string;
+  height?: string;
+  minHeight?: string;
+  editorId?: string;
+  language?: string;
+  useDefaultHTMLSanitizer?: boolean;
+  useCommandShortcut?: boolean;
+  usageStatistics?: boolean;
+  toolbarItems?: string[];
+  hideModeSwitch?: boolean;
+  linkAttribute?: any;
+  extendedAutolinks?: boolean;
+  customConvertor?: any;
+  customHTMLRenderer?: any;
+  referenceDefinition?: boolean;
+  customHTMLSanitizer?: (params: any) => any;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-tui",
-  "version": "2.0.0",
+  "version": "2.1.0-rc.0",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
Fixes #4

I've published this as the `ngx-tui@next` tag on [npm](https://www.npmjs.com/package/ngx-tui/v/2.1.0-rc.0).